### PR TITLE
Package template files unconditionally

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
   "jinja2",
 ]
 
+[tool.setuptools.package-data]
+"*" = ["*.jinja"]
+
 [project.optional-dependencies]
 test = [
   "jinja2",


### PR DESCRIPTION
These files were being included when building from a git working copy, but not when copied into a container image.