### PR TITLE
CAMP error on unknown object instead of injecting text

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -34,7 +34,7 @@ on:
     - cron: '0 0 * * 0'
 
 env:
-  ACE_REPO: "git+https://github.com/JHUAPL-DTNMA/dtnma-ace.git@main"
+  ACE_REPO: "git+https://github.com/JHUAPL-DTNMA/dtnma-ace.git@119-compat-follow"
 
 jobs:
   build:

--- a/src/camp/generators/data/agent.c.jinja
+++ b/src/camp/generators/data/agent.c.jinja
@@ -195,12 +195,8 @@ cace_ari_set_aritype({{ptrname}}, {{value.value | cpp_enum}});
 {% endif %}
 {%- elif value is instance(ari.ReferenceARI) -%}
 {% set refdobj = value | deref -%}
-{%- if refdobj -%}
 // reference to {{value | as_text}}
 cace_ari_set_objref_path_intid({{ptrname}}, {{refdobj.module.ns_org_enum | c_int}}, {{refdobj.module.ns_model_enum | c_int}}, {{value.ident.type_id | cpp_enum}}, {{refdobj.enum | c_int}});
-{%- else -%}
-// FIXME reference to unknown object {{value | as_text}}
-{%- endif %}
 {%- endif %}
 {%- endmacro -%}
 

--- a/src/camp/generators/lib/campch.py
+++ b/src/camp/generators/lib/campch.py
@@ -23,18 +23,18 @@
 #
 import io
 import logging
-import ace.models
 import jinja2
 import numpy
 import textwrap
-from typing import Union, Optional
-import ace
-from ace import models, ari, ari_text, typing
+from typing import cast, Union, Optional
+import ace.models
+import ace.typing, ace.type_constraint
+from ace import models, ari, ari_text
 from ace.lookup import dereference, ORM_TYPE
 
 LOGGER = logging.getLogger(__name__)
 
-AdmEntity = Union[models.AdmModule, models.AdmObjMixin]
+AdmEntity = Union[ari.StructType, models.AdmModule, models.AdmObjMixin]
 ''' Either an ADM itself or an AMM object defined within one. '''
 
 
@@ -77,12 +77,17 @@ def update_jinja_env(env: jinja2.Environment, admset, sym_prefix: str):
         '''
         if isinstance(value, ari.StructType):
             return 'CACE_ARI_TYPE_' + value.name
-        elif isinstance(value, models.AdmModule):
+
+        module: models.AdmModule
+        if isinstance(value, models.AdmModule):
             module = value
             parts = ['adm']
         elif isinstance(value, models.AdmObjMixin):
-            module = value.module
+            module = cast(models.AdmModule, value.module)
             parts = ['objid', amm_obj_type(value).name, yang_to_c(value.name)]
+        else:
+            raise RuntimeError('No module name available')
+
         return '_'.join([sym_prefix, yang_to_c(module.module_name), 'enum'] + parts).upper()
 
     def c_depth(name: str, depth: int) -> str:
@@ -96,7 +101,11 @@ def update_jinja_env(env: jinja2.Environment, admset, sym_prefix: str):
         if isinstance(value, models.AdmModule):
             parts = [yang_to_c(value.module_name)]
         elif isinstance(value, models.AdmObjMixin):
-            parts = list(map(yang_to_c, [value.module.module_name, amm_obj_type(value).name, value.name]))
+            module = cast(models.AdmModule, value.module)
+            parts = list(map(yang_to_c, [module.module_name, amm_obj_type(value).name, value.name]))
+        else:
+            raise RuntimeError('No C function name available')
+
         if suffix:
             parts.append(suffix)
         return '_'.join([sym_prefix] + parts).lower()
@@ -148,10 +157,10 @@ def update_jinja_env(env: jinja2.Environment, admset, sym_prefix: str):
         '''
         return prefix.join(textwrap.wrap(value))
 
-    def as_text(val: Union[ari.ARI, typing.BaseType]) -> str:
+    def as_text(val: Union[ari.ARI, ace.typing.BaseType]) -> str:
         ''' Encode an ARI or as text form URI.
         '''
-        if isinstance(val, typing.BaseType):
+        if isinstance(val, ace.typing.BaseType):
             val = val.ari_name()
 
         enc = ari_text.Encoder()
@@ -177,14 +186,19 @@ def update_jinja_env(env: jinja2.Environment, admset, sym_prefix: str):
         '''
         return f'./{amm_obj_type(obj).name}/{obj.norm_name}'
 
-    def deref(ari: ari.ARI) -> models.AdmObjMixin:
+    def deref(ari: ari.ReferenceARI) -> models.AdmObjMixin:
         ''' Dereference an ARI into an AMM object.
         '''
         LOGGER.debug('deref from %s', ari)
-        return dereference(ari, admset.db_session())
+        obj = dereference(ari, admset.db_session())
+
+        if obj is None:
+            LOGGER.error('deref got no object named %s', as_text(ari))
+            raise RuntimeError(f'No such object named {as_text(ari)}')
+        return obj
 
     def ari_builtin(ari: ari.ARI, typename: str) -> bool:
-        typeobj = typing.BUILTINS[typename]
+        typeobj = ace.typing.BUILTINS[typename]
         got = typeobj.get(ari)
         return got is not None
 

--- a/src/camp/generators/lib/campch.py
+++ b/src/camp/generators/lib/campch.py
@@ -28,7 +28,8 @@ import numpy
 import textwrap
 from typing import cast, Union, Optional
 import ace.models
-import ace.typing, ace.type_constraint
+import ace.typing
+import ace.type_constraint
 from ace import models, ari, ari_text
 from ace.lookup import dereference, ORM_TYPE
 

--- a/src/camp/generators/lib/campch_roundtrip.py
+++ b/src/camp/generators/lib/campch_roundtrip.py
@@ -22,16 +22,19 @@
 #
 import logging
 import re
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 LOGGER = logging.getLogger(__name__)
 
 
-#
-# Class to handle scraping files, and writing custom tags and code to
-# newly-generated files.
-#
 class Scraper(object):
+    ''' Class to handle scraping files, and writing custom tags and code to
+    newly-generated files.
+    '''
+
+    def __init__(self):
+        self.includes = []
+        self.functions = []
 
     # HELPER FUNCTIONS TO MAKE \CUSTOM\ TAGS FOR FILE #
 
@@ -262,7 +265,7 @@ class C_Scraper(Scraper):
     # as the key, and the value is a list of strings that make up the custom body
     # of that function.
     #
-    def __init__(self, filename: str):
+    def __init__(self, filename: Optional[str]):
         self.filename = filename
         self.includes: List[str] = ["/*             NONE              */\n"]
         self.functions: List[str] = ["/*             NONE              */\n"]
@@ -306,7 +309,7 @@ class H_Scraper(Scraper):
     #
     # Constructor for the H_Scraper class
     #
-    def __init__(self, filename: str):
+    def __init__(self, filename: Optional[str]):
         self.filename = filename
         self.includes: List[str] = ["/*             NONE              */\n"]
         self.functions: List[str] = ["/*             NONE              */\n"]

--- a/test/data/example-test.yang
+++ b/test/data/example-test.yang
@@ -223,12 +223,34 @@ module example-test {
       amm:type "/ARITYPE/UVAST";
     }
   }
+  amm:oper compare-lt {
+    amm:enum 1;
+    description
+      "Compare values for less-than predicate.
+       The operands are cast to the least compatible numeric type
+       before the comparison.";
+    amm:operand left {
+      description
+        "The left-side operand.";
+      amm:type "/ARITYPE/UVAST";
+    }
+    amm:operand right {
+      description
+        "The left-side operand.";
+      amm:type "/ARITYPE/UVAST";
+    }
+    amm:result result {
+      description
+        "The comparison result.";
+      amm:type "/ARITYPE/bool";
+    }
+  }
   amm:sbr sbr1 {
     amm:enum 8;
     description
       "";
-    amm:action "/AC/(./CTRL/first,./CTRL/second)";
-    amm:condition "/AC/(./EDD/sensor,./VAR/min_threshold,./OPER/compare_lt)";
+    amm:action "/AC/(./CTRL/get,./CTRL/set)";
+    amm:condition "/AC/(./EDD/edd_uvast,./VAR/var_uvast_val,./OPER/compare-lt)";
     amm:min-interval "/TD/PT30S";
     amm:max-count 10;
     amm:init-enabled false;
@@ -237,14 +259,14 @@ module example-test {
     amm:enum 9;
     description
       "";
-    amm:action "/AC/(./CTRL/first,./CTRL/second)";
-    amm:condition "/AC/(./EDD/sensor,./VAR/min_threshold,./OPER/compare_lt)";
+    amm:action "/AC/(./CTRL/get,./CTRL/set)";
+    amm:condition "/AC/(./EDD/edd_uvast,./VAR/var_uvast_val,./OPER/compare-lt)";
   }
   amm:tbr tbr_rule {
     amm:enum 30;
     description
       "Generate telemetry reports.";
-    amm:action "/AC/(./CTRL/first,./CTRL/other)";
+    amm:action "/AC/(./CTRL/get,./CTRL/set)";
     amm:start "/TP/20.5";
     amm:period "/TD/PT30S";
   }

--- a/test/data/gen_ch/example_test.c.jinja
+++ b/test/data/gen_ch/example_test.c.jinja
@@ -271,6 +271,34 @@ static void refda_adm_example_test_oper_add(refda_oper_eval_ctx_t *ctx)
 	 */
 }
 
+
+/* Name: compare-lt
+ * Description:
+ *   Compare values for less-than predicate. The operands are cast to the
+ *   least compatible numeric type before the comparison.
+ *
+ * Parameters: none
+ *
+ * Operand list:
+ *   - Index 0, name "left", type use of ari:/ARITYPE/UVAST
+ *   - Index 1, name "right", type use of ari:/ARITYPE/UVAST
+ *
+ * Result name "result", type use of ari:/ARITYPE/BOOL
+ */
+static void refda_adm_example_test_oper_compare_lt(refda_oper_eval_ctx_t *ctx)
+{
+	/*
+	 * +-------------------------------------------------------------------------+
+	 * |START CUSTOM FUNCTION refda_adm_example_test_oper_compare_lt BODY
+	 * +-------------------------------------------------------------------------+
+	 */
+	/*
+	 * +-------------------------------------------------------------------------+
+	 * |STOP CUSTOM FUNCTION refda_adm_example_test_oper_compare_lt BODY
+	 * +-------------------------------------------------------------------------+
+	 */
+}
+
 int refda_adm_example_test_init(refda_agent_t *agent)
 {
     CHKERR1(agent);
@@ -740,6 +768,44 @@ int refda_adm_example_test_init(refda_agent_t *agent)
             obj = refda_register_oper(adm, cace_amm_idseg_ref_withenum("add", REFDA_ADM_EXAMPLE_TEST_ENUM_OBJID_OPER_ADD), objdata);
             // no parameters
         }
+        { // For ./OPER/compare-lt
+            refda_amm_oper_desc_t *objdata = CACE_MALLOC(sizeof(refda_amm_oper_desc_t));
+            refda_amm_oper_desc_init(objdata);
+            // operands:
+            cace_amm_named_type_array_resize(objdata->operand_types, 2);
+            {
+                cace_amm_named_type_t *operand = cace_amm_named_type_array_get(objdata->operand_types, 0);
+                m_string_set_cstr(operand->name, "left");
+                {
+                    cace_ari_t typeref = CACE_ARI_INIT_UNDEFINED;
+                    // use of ari:/ARITYPE/UVAST
+                    cace_ari_set_aritype(&typeref, CACE_ARI_TYPE_UVAST);
+                    cace_amm_type_set_use_ref_move(&(operand->typeobj), &typeref);
+                }
+            }
+            {
+                cace_amm_named_type_t *operand = cace_amm_named_type_array_get(objdata->operand_types, 1);
+                m_string_set_cstr(operand->name, "right");
+                {
+                    cace_ari_t typeref = CACE_ARI_INIT_UNDEFINED;
+                    // use of ari:/ARITYPE/UVAST
+                    cace_ari_set_aritype(&typeref, CACE_ARI_TYPE_UVAST);
+                    cace_amm_type_set_use_ref_move(&(operand->typeobj), &typeref);
+                }
+            }
+            // result type:
+            {
+                cace_ari_t typeref = CACE_ARI_INIT_UNDEFINED;
+                // use of ari:/ARITYPE/BOOL
+                cace_ari_set_aritype(&typeref, CACE_ARI_TYPE_BOOL);
+                cace_amm_type_set_use_ref_move(&(objdata->res_type), &typeref);
+            }
+            // callback:
+            objdata->evaluate = refda_adm_example_test_oper_compare_lt;
+
+            obj = refda_register_oper(adm, cace_amm_idseg_ref_withenum("compare-lt", REFDA_ADM_EXAMPLE_TEST_ENUM_OBJID_OPER_COMPARE_LT), objdata);
+            // no parameters
+        }
 
         /**
          * Register SBR objects
@@ -752,11 +818,13 @@ int refda_adm_example_test_init(refda_agent_t *agent)
                 cace_ari_ac_t *acinit = cace_ari_set_ac(&(objdata->action), NULL);
                 {
                     cace_ari_t *item = cace_ari_list_push_back_new(acinit->items);
-                    // FIXME reference to unknown object ari://example/test/CTRL/first
+                    // reference to ari://example/test/CTRL/get
+                    cace_ari_set_objref_path_intid(item, 65535, 9999, CACE_ARI_TYPE_CTRL, 2);
                 }
                 {
                     cace_ari_t *item = cace_ari_list_push_back_new(acinit->items);
-                    // FIXME reference to unknown object ari://example/test/CTRL/second
+                    // reference to ari://example/test/CTRL/set
+                    cace_ari_set_objref_path_intid(item, 65535, 9999, CACE_ARI_TYPE_CTRL, 3);
                 }
             }
             // condition
@@ -764,15 +832,18 @@ int refda_adm_example_test_init(refda_agent_t *agent)
                 cace_ari_ac_t *acinit = cace_ari_set_ac(&(objdata->condition), NULL);
                 {
                     cace_ari_t *item = cace_ari_list_push_back_new(acinit->items);
-                    // FIXME reference to unknown object ari://example/test/EDD/sensor
+                    // reference to ari://example/test/EDD/edd_uvast
+                    cace_ari_set_objref_path_intid(item, 65535, 9999, CACE_ARI_TYPE_EDD, 0);
                 }
                 {
                     cace_ari_t *item = cace_ari_list_push_back_new(acinit->items);
-                    // FIXME reference to unknown object ari://example/test/VAR/min_threshold
+                    // reference to ari://example/test/VAR/var_uvast_val
+                    cace_ari_set_objref_path_intid(item, 65535, 9999, CACE_ARI_TYPE_VAR, 0);
                 }
                 {
                     cace_ari_t *item = cace_ari_list_push_back_new(acinit->items);
-                    // FIXME reference to unknown object ari://example/test/OPER/compare_lt
+                    // reference to ari://example/test/OPER/compare-lt
+                    cace_ari_set_objref_path_intid(item, 65535, 9999, CACE_ARI_TYPE_OPER, 1);
                 }
             }
             // min_interval
@@ -795,11 +866,13 @@ int refda_adm_example_test_init(refda_agent_t *agent)
                 cace_ari_ac_t *acinit = cace_ari_set_ac(&(objdata->action), NULL);
                 {
                     cace_ari_t *item = cace_ari_list_push_back_new(acinit->items);
-                    // FIXME reference to unknown object ari://example/test/CTRL/first
+                    // reference to ari://example/test/CTRL/get
+                    cace_ari_set_objref_path_intid(item, 65535, 9999, CACE_ARI_TYPE_CTRL, 2);
                 }
                 {
                     cace_ari_t *item = cace_ari_list_push_back_new(acinit->items);
-                    // FIXME reference to unknown object ari://example/test/CTRL/second
+                    // reference to ari://example/test/CTRL/set
+                    cace_ari_set_objref_path_intid(item, 65535, 9999, CACE_ARI_TYPE_CTRL, 3);
                 }
             }
             // condition
@@ -807,15 +880,18 @@ int refda_adm_example_test_init(refda_agent_t *agent)
                 cace_ari_ac_t *acinit = cace_ari_set_ac(&(objdata->condition), NULL);
                 {
                     cace_ari_t *item = cace_ari_list_push_back_new(acinit->items);
-                    // FIXME reference to unknown object ari://example/test/EDD/sensor
+                    // reference to ari://example/test/EDD/edd_uvast
+                    cace_ari_set_objref_path_intid(item, 65535, 9999, CACE_ARI_TYPE_EDD, 0);
                 }
                 {
                     cace_ari_t *item = cace_ari_list_push_back_new(acinit->items);
-                    // FIXME reference to unknown object ari://example/test/VAR/min_threshold
+                    // reference to ari://example/test/VAR/var_uvast_val
+                    cace_ari_set_objref_path_intid(item, 65535, 9999, CACE_ARI_TYPE_VAR, 0);
                 }
                 {
                     cace_ari_t *item = cace_ari_list_push_back_new(acinit->items);
-                    // FIXME reference to unknown object ari://example/test/OPER/compare_lt
+                    // reference to ari://example/test/OPER/compare-lt
+                    cace_ari_set_objref_path_intid(item, 65535, 9999, CACE_ARI_TYPE_OPER, 1);
                 }
             }
             // min_interval
@@ -842,11 +918,13 @@ int refda_adm_example_test_init(refda_agent_t *agent)
                 cace_ari_ac_t *acinit = cace_ari_set_ac(&(objdata->action), NULL);
                 {
                     cace_ari_t *item = cace_ari_list_push_back_new(acinit->items);
-                    // FIXME reference to unknown object ari://example/test/CTRL/first
+                    // reference to ari://example/test/CTRL/get
+                    cace_ari_set_objref_path_intid(item, 65535, 9999, CACE_ARI_TYPE_CTRL, 2);
                 }
                 {
                     cace_ari_t *item = cace_ari_list_push_back_new(acinit->items);
-                    // FIXME reference to unknown object ari://example/test/CTRL/other
+                    // reference to ari://example/test/CTRL/set
+                    cace_ari_set_objref_path_intid(item, 65535, 9999, CACE_ARI_TYPE_CTRL, 3);
                 }
             }
             // period

--- a/test/data/gen_ch/example_test.h.jinja
+++ b/test/data/gen_ch/example_test.h.jinja
@@ -79,6 +79,8 @@ extern "C" {
  */
 /// For ./OPER/add
 #define REFDA_ADM_EXAMPLE_TEST_ENUM_OBJID_OPER_ADD 0
+/// For ./OPER/compare-lt
+#define REFDA_ADM_EXAMPLE_TEST_ENUM_OBJID_OPER_COMPARE_LT 1
 
 /*
  * Enumerations for SBR objects

--- a/test/data/pgsql/example_test.sql.jinja
+++ b/test/data/pgsql/example_test.sql.jinja
@@ -62,6 +62,9 @@ edd_endpoint_active_aid INTEGER;
 oper_add_oid INTEGER;
 oper_add_fid INTEGER;
 oper_add_aid INTEGER;
+oper_compare_lt_oid INTEGER;
+oper_compare_lt_fid INTEGER;
+oper_compare_lt_aid INTEGER;
 
 sbr_sbr1_oid INTEGER;
 sbr_sbr1_fid INTEGER;
@@ -163,6 +166,12 @@ CALL SP__insert_obj_metadata(-6, 'add', r_data_model_id, 0, null, null, 'Add two
 
 CALL SP__insert_operator_formal_definition(oper_add_oid, 'Add two uvast values. The operands are cast to the least compatible numeric type before the arithmetic.', null, 2, '.left, .right', 'result', '', oper_add_fid);
 CALL SP__insert_operator_actual_definition(oper_add_oid, 'The singleton value for add', null, oper_add_aid);
+
+CALL SP__insert_obj_metadata(-6, 'compare-lt', r_data_model_id, 1, null, null, 'Compare values for less-than predicate. The operands are cast to the least compatible numeric type before the comparison.', oper_compare_lt_oid);
+
+
+CALL SP__insert_operator_formal_definition(oper_compare_lt_oid, 'Compare values for less-than predicate. The operands are cast to the least compatible numeric type before the comparison.', null, 2, '.left, .right', 'result', '', oper_compare_lt_fid);
+CALL SP__insert_operator_actual_definition(oper_compare_lt_oid, 'The singleton value for compare-lt', null, oper_compare_lt_aid);
 
 
 

--- a/test/test_generators.py
+++ b/test/test_generators.py
@@ -28,7 +28,6 @@ import os
 import unittest
 import jinja2
 from ace import AdmSet, Checker
-from camp.generators.lib.campch_roundtrip import H_Scraper, C_Scraper
 from camp.generators import (
     create_sql,
     create_impl_h,

--- a/test/test_generators.py
+++ b/test/test_generators.py
@@ -40,6 +40,10 @@ LOGGER = logging.getLogger(__name__)
 ''' Logger for this module '''
 SELFDIR = os.path.dirname(__file__)
 ''' Directory containing this file '''
+logging.getLogger('ace').setLevel(logging.ERROR)
+
+# ADM handling outside of tests
+ADMS = AdmSet(cache_dir=False)
 
 
 class BaseTest(unittest.TestCase):
@@ -58,15 +62,14 @@ class BaseTest(unittest.TestCase):
         logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
         self._dir = TmpDir()
         LOGGER.info('Working in %s', self._dir)
-        self._admset = AdmSet()
 
     def _get_adm(self, file_name):
         ''' Read an ADM file from the 'tests/data' directory.
         '''
         admfile = os.path.join(SELFDIR, 'data', file_name)
         LOGGER.info("Loading %s ... ", admfile)
-        adm = self._admset.load_from_file(admfile)
-        errs = Checker(self._admset.db_session()).check(adm)
+        adm = ADMS.load_from_file(admfile)
+        errs = Checker(ADMS.db_session()).check(adm)
         self.assertEqual([], errs)
         return adm
 
@@ -82,7 +85,7 @@ class TestCreateSql(BaseTest):
         adm = self._get_adm('example-test.yang')
         outdir = os.path.join(os.environ['XDG_DATA_HOME'], 'out')
 
-        writer = create_sql.Writer(self._admset, adm, outdir, dialect='pgsql')
+        writer = create_sql.Writer(ADMS, adm, outdir, dialect='pgsql')
         out_path = writer.file_path()
         self.assertEqual(
             os.path.join(outdir, 'example_test.sql'),
@@ -107,7 +110,7 @@ class TestCreateCH(BaseTest):
         outdir = os.path.join(os.environ['XDG_DATA_HOME'], 'out')
         LOGGER.info('Writing to %s', outdir)
 
-        writer = create_impl_h.Writer(self._admset, adm, outdir, H_Scraper(None))
+        writer = create_impl_h.Writer(ADMS, adm, outdir, scrape=False)
         out_path = writer.file_path()
         self.assertEqual(
             os.path.join(outdir, 'example_test.h'),
@@ -128,7 +131,7 @@ class TestCreateCH(BaseTest):
         adm = self._get_adm('example-test.yang')
         outdir = os.path.join(os.environ['XDG_DATA_HOME'], 'out')
 
-        writer = create_impl_c.Writer(self._admset, adm, outdir, C_Scraper(None))
+        writer = create_impl_c.Writer(ADMS, adm, outdir, scrape=False)
         out_path = writer.file_path()
         self.assertEqual(
             os.path.join(outdir, 'example_test.c'),


### PR DESCRIPTION
Also tighten typing interfaces for type checkers.

Closes #68 