### PR TITLE
Emit more ADM information to header file

### DIFF
--- a/src/camp/generators/data/agent.c.jinja
+++ b/src/camp/generators/data/agent.c.jinja
@@ -413,9 +413,12 @@ int {{adm | c_func(suffix='init')}}(refda_agent_t *agent)
     /*   START CUSTOM PRE-INIT HERE */
 {{scraper.pre_init_lines | join('') }}    /*   STOP CUSTOM PRE-INIT HERE  */
 
+    /* Updated to pull macros instead of hard-coded string */
     cace_amm_obj_ns_t *adm = cace_amm_obj_store_add_ns(
-        &(agent->objs), cace_amm_idseg_ref_withenum({{adm.ns_org_name | c_str}}, {{adm.ns_org_enum | c_int}}),
-        cace_amm_idseg_ref_withenum({{adm.ns_model_name | c_str}}, {{adm | cpp_enum}}), {{adm.latest_revision_date | c_str}});
+        &(agent->objs), 
+        cace_amm_idseg_ref_withenum({{adm | cpp_enum}}_ORG_NAME, {{adm | cpp_enum}}_ORG_ID),
+        cace_amm_idseg_ref_withenum({{adm | cpp_enum}}_MOD_NAME, {{adm | cpp_enum}}), 
+        {{adm | cpp_enum}}_REVISION);
     if (adm)
     {
         cace_amm_obj_desc_t *obj;

--- a/src/camp/generators/data/agent.c.jinja
+++ b/src/camp/generators/data/agent.c.jinja
@@ -416,9 +416,9 @@ int {{adm | c_func(suffix='init')}}(refda_agent_t *agent)
     /* Updated to pull macros instead of hard-coded string */
     cace_amm_obj_ns_t *adm = cace_amm_obj_store_add_ns(
         &(agent->objs), 
-        cace_amm_idseg_ref_withenum({{adm | cpp_str}}_ORG_NAME, {{adm | cpp_str}}_ORG_ID),
-        cace_amm_idseg_ref_withenum({{adm | cpp_str}}_MOD_NAME, {{adm | cpp_str}}), 
-        {{adm | cpp_str}}_REVISION);
+        cace_amm_idseg_ref_withenum({{adm | c_str}}_ORG_NAME, {{adm | c_str}}_ORG_ID),
+        cace_amm_idseg_ref_withenum({{adm | c_str}}_MOD_NAME, {{adm | c_str}}), 
+        {{adm | c_str}}_REVISION);
     if (adm)
     {
         cace_amm_obj_desc_t *obj;

--- a/src/camp/generators/data/agent.c.jinja
+++ b/src/camp/generators/data/agent.c.jinja
@@ -413,12 +413,12 @@ int {{adm | c_func(suffix='init')}}(refda_agent_t *agent)
     /*   START CUSTOM PRE-INIT HERE */
 {{scraper.pre_init_lines | join('') }}    /*   STOP CUSTOM PRE-INIT HERE  */
 
-    /* Updated to pull macros instead of hard-coded string */
     cace_amm_obj_ns_t *adm = cace_amm_obj_store_add_ns(
-        &(agent->objs), 
-        cace_amm_idseg_ref_withenum({{adm | c_str}}_ORG_NAME, {{adm | c_str}}_ORG_ID),
-        cace_amm_idseg_ref_withenum({{adm | c_str}}_MOD_NAME, {{adm | c_str}}), 
-        {{adm | c_str}}_REVISION);
+        &(agent->objs),
+        cace_amm_idseg_ref_withenum({{adm | cpp_enum}}_ORG_NAME, {{adm | cpp_enum}}_ORG_ENUM),
+        cace_amm_idseg_ref_withenum({{adm | cpp_enum}}_MODEL_NAME, {{adm | cpp_enum}}_MODEL_ENUM),
+        {{adm | cpp_enum}}_MODEL_REVISION
+    );
     if (adm)
     {
         cace_amm_obj_desc_t *obj;

--- a/src/camp/generators/data/agent.c.jinja
+++ b/src/camp/generators/data/agent.c.jinja
@@ -416,9 +416,9 @@ int {{adm | c_func(suffix='init')}}(refda_agent_t *agent)
     /* Updated to pull macros instead of hard-coded string */
     cace_amm_obj_ns_t *adm = cace_amm_obj_store_add_ns(
         &(agent->objs), 
-        cace_amm_idseg_ref_withenum({{adm | cpp_enum}}_ORG_NAME, {{adm | cpp_enum}}_ORG_ID),
-        cace_amm_idseg_ref_withenum({{adm | cpp_enum}}_MOD_NAME, {{adm | cpp_enum}}), 
-        {{adm | cpp_enum}}_REVISION);
+        cace_amm_idseg_ref_withenum({{adm | cpp_str}}_ORG_NAME, {{adm | cpp_str}}_ORG_ID),
+        cace_amm_idseg_ref_withenum({{adm | cpp_str}}_MOD_NAME, {{adm | cpp_str}}), 
+        {{adm | cpp_str}}_REVISION);
     if (adm)
     {
         cace_amm_obj_desc_t *obj;

--- a/src/camp/generators/data/agent.h.jinja
+++ b/src/camp/generators/data/agent.h.jinja
@@ -31,14 +31,19 @@
 extern "C" {
 #endif
 
-/// Enumeration of the ADM itself
-#define {{adm | cpp_enum}} {{adm.ns_model_enum | c_int}}
-
-/// ADM constants for generated header files 
-#define {{adm | c_str}}_ORG_NAME "{{adm.ns_org_name}}"
-#define {{adm | c_str}}_ORG_ID {{adm.ns_org_enum | c_int}}
-#define {{adm | c_str}}_MOD_NAME "{{adm.module_name}}"
-#define {{adm | c_str}}_REVISION "{{adm.revision}}"
+/*
+ * Defines for the ADM itself
+ */
+/// Text name of the organization
+#define {{adm | cpp_enum}}_ORG_NAME {{adm.ns_org_name | c_str}}
+/// Enumeration of the organization
+#define {{adm | cpp_enum}}_ORG_ENUM {{adm.ns_org_enum | c_int}}
+/// Text name of the model
+#define {{adm | cpp_enum}}_MODEL_NAME {{adm.ns_model_name | c_str}}
+/// Enumeration of the model
+#define {{adm | cpp_enum}}_MODEL_ENUM {{adm.ns_model_enum | c_int}}
+/// Revision date for the model
+#define {{adm | cpp_enum}}_MODEL_REVISION {{adm.latest_revision_date | c_str}}
 
 
 {%- if adm.ident %}

--- a/src/camp/generators/data/agent.h.jinja
+++ b/src/camp/generators/data/agent.h.jinja
@@ -27,18 +27,19 @@
 {{scraper.includes | join('') -}}
 /*   STOP CUSTOM INCLUDES HERE  */
 
-/* ADM constants for generated header files */
-#define {{adm | cpp_enum}}_ORG_NAME "{{adm.ns_org_name}}"
-#define {{adm | cpp_enum}}_ORG_ID {{adm.ns_org_enum | c_int}}
-#define {{adm | cpp_enum}}_MOD_NAME "{{adm.module_name}}"
-#define {{adm | cpp_enum}}_REVISION "{{adm.revision}}"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /// Enumeration of the ADM itself
 #define {{adm | cpp_enum}} {{adm.ns_model_enum | c_int}}
+
+/// ADM constants for generated header files 
+#define {{adm | cpp_str}}_ORG_NAME "{{adm.ns_org_name}}"
+#define {{adm | cpp_str}}_ORG_ID {{adm.ns_org_enum | c_int}}
+#define {{adm | cpp_str}}_MOD_NAME "{{adm.module_name}}"
+#define {{adm | cpp_str}}_REVISION "{{adm.revision}}"
+
 
 {%- if adm.ident %}
 
@@ -53,7 +54,7 @@ extern "C" {
 {%- if adm.typedef %}
 
 /*
- * Enumerations for TYPEDEF objects
+ * Enumerations for rTYPEDEF objects
  */
 {%- for obj in adm.typedef %}
 {{obj_enum(obj)}}

--- a/src/camp/generators/data/agent.h.jinja
+++ b/src/camp/generators/data/agent.h.jinja
@@ -54,7 +54,7 @@ extern "C" {
 {%- if adm.typedef %}
 
 /*
- * Enumerations for rTYPEDEF objects
+ * Enumerations for TYPEDEF objects
  */
 {%- for obj in adm.typedef %}
 {{obj_enum(obj)}}

--- a/src/camp/generators/data/agent.h.jinja
+++ b/src/camp/generators/data/agent.h.jinja
@@ -27,6 +27,12 @@
 {{scraper.includes | join('') -}}
 /*   STOP CUSTOM INCLUDES HERE  */
 
+/* ADM constants for generated header files */
+#define {{adm | cpp_enum}}_ORG_NAME "{{adm.org_name}}"
+#define {{adm | cpp_enum}}_ORG_ID {{adm.org_id | c_int}}
+#define {{adm | cpp_enum}}_MOD_NAME "{{adm.module_name}}"
+#define {{adm | cpp_enum}}_REVISION "{{adm.revision}}"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/camp/generators/data/agent.h.jinja
+++ b/src/camp/generators/data/agent.h.jinja
@@ -35,10 +35,10 @@ extern "C" {
 #define {{adm | cpp_enum}} {{adm.ns_model_enum | c_int}}
 
 /// ADM constants for generated header files 
-#define {{adm | cpp_str}}_ORG_NAME "{{adm.ns_org_name}}"
-#define {{adm | cpp_str}}_ORG_ID {{adm.ns_org_enum | c_int}}
-#define {{adm | cpp_str}}_MOD_NAME "{{adm.module_name}}"
-#define {{adm | cpp_str}}_REVISION "{{adm.revision}}"
+#define {{adm | c_str}}_ORG_NAME "{{adm.ns_org_name}}"
+#define {{adm | c_str}}_ORG_ID {{adm.ns_org_enum | c_int}}
+#define {{adm | c_str}}_MOD_NAME "{{adm.module_name}}"
+#define {{adm | c_str}}_REVISION "{{adm.revision}}"
 
 
 {%- if adm.ident %}

--- a/src/camp/generators/data/agent.h.jinja
+++ b/src/camp/generators/data/agent.h.jinja
@@ -44,6 +44,8 @@ extern "C" {
 #define {{adm | cpp_enum}}_MODEL_ENUM {{adm.ns_model_enum | c_int}}
 /// Revision date for the model
 #define {{adm | cpp_enum}}_MODEL_REVISION {{adm.latest_revision_date | c_str}}
+/// @deprecated use {{adm | cpp_enum}}_MODEL_ENUM directly
+#define {{adm | cpp_enum}}_ENUM_ADM {{adm | cpp_enum}}_MODEL_ENUM
 
 
 {%- if adm.ident %}

--- a/src/camp/generators/data/agent.h.jinja
+++ b/src/camp/generators/data/agent.h.jinja
@@ -28,8 +28,8 @@
 /*   STOP CUSTOM INCLUDES HERE  */
 
 /* ADM constants for generated header files */
-#define {{adm | cpp_enum}}_ORG_NAME "{{adm.org_name}}"
-#define {{adm | cpp_enum}}_ORG_ID {{adm.org_id | c_int}}
+#define {{adm | cpp_enum}}_ORG_NAME "{{adm.ns_org_name}}"
+#define {{adm | cpp_enum}}_ORG_ID {{adm.ns_org_enum | c_int}}
 #define {{adm | cpp_enum}}_MOD_NAME "{{adm.module_name}}"
 #define {{adm | cpp_enum}}_REVISION "{{adm.revision}}"
 

--- a/src/camp/generators/lib/campch.py
+++ b/src/camp/generators/lib/campch.py
@@ -83,7 +83,7 @@ def update_jinja_env(env: jinja2.Environment, admset, sym_prefix: str):
         module: models.AdmModule
         if isinstance(value, models.AdmModule):
             module = value
-            parts = ['adm']
+            parts = []
         elif isinstance(value, models.AdmObjMixin):
             module = cast(models.AdmModule, value.module)
             parts = ['enum', 'objid', amm_obj_type(value).name, yang_to_c(value.name)]

--- a/src/camp/generators/lib/campch.py
+++ b/src/camp/generators/lib/campch.py
@@ -86,11 +86,11 @@ def update_jinja_env(env: jinja2.Environment, admset, sym_prefix: str):
             parts = ['adm']
         elif isinstance(value, models.AdmObjMixin):
             module = cast(models.AdmModule, value.module)
-            parts = ['objid', amm_obj_type(value).name, yang_to_c(value.name)]
+            parts = ['enum', 'objid', amm_obj_type(value).name, yang_to_c(value.name)]
         else:
             raise RuntimeError('No module name available')
 
-        return '_'.join([sym_prefix, yang_to_c(module.module_name), 'enum'] + parts).upper()
+        return '_'.join([sym_prefix, yang_to_c(module.module_name)] + parts).upper()
 
     def c_depth(name: str, depth: int) -> str:
         if depth == 0:

--- a/test/data/gen_ch/example_test.c
+++ b/test/data/gen_ch/example_test.c
@@ -303,8 +303,11 @@ int refda_adm_example_test_init(refda_agent_t *agent)
     /*   STOP CUSTOM PRE-INIT HERE  */
 
     cace_amm_obj_ns_t *adm = cace_amm_obj_store_add_ns(
-        &(agent->objs), cace_amm_idseg_ref_withenum("example", 65535),
-        cace_amm_idseg_ref_withenum("test", REFDA_ADM_EXAMPLE_TEST_ENUM_ADM), "2024-11-21");
+        &(agent->objs),
+        cace_amm_idseg_ref_withenum(REFDA_ADM_EXAMPLE_TEST_ADM_ORG_NAME, REFDA_ADM_EXAMPLE_TEST_ADM_ORG_ENUM),
+        cace_amm_idseg_ref_withenum(REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_NAME, REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM),
+        REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_REVISION
+    );
     if (adm)
     {
         cace_amm_obj_desc_t *obj;

--- a/test/data/gen_ch/example_test.c
+++ b/test/data/gen_ch/example_test.c
@@ -304,9 +304,9 @@ int refda_adm_example_test_init(refda_agent_t *agent)
 
     cace_amm_obj_ns_t *adm = cace_amm_obj_store_add_ns(
         &(agent->objs),
-        cace_amm_idseg_ref_withenum(REFDA_ADM_EXAMPLE_TEST_ADM_ORG_NAME, REFDA_ADM_EXAMPLE_TEST_ADM_ORG_ENUM),
-        cace_amm_idseg_ref_withenum(REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_NAME, REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM),
-        REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_REVISION
+        cace_amm_idseg_ref_withenum(REFDA_ADM_EXAMPLE_TEST_ORG_NAME, REFDA_ADM_EXAMPLE_TEST_ORG_ENUM),
+        cace_amm_idseg_ref_withenum(REFDA_ADM_EXAMPLE_TEST_MODEL_NAME, REFDA_ADM_EXAMPLE_TEST_MODEL_ENUM),
+        REFDA_ADM_EXAMPLE_TEST_MODEL_REVISION
     );
     if (adm)
     {

--- a/test/data/gen_ch/example_test.h
+++ b/test/data/gen_ch/example_test.h
@@ -33,6 +33,8 @@ extern "C" {
 #define REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM 9999
 /// Revision date for the model
 #define REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_REVISION "2024-11-21"
+/// @deprecated use REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM directly
+#define REFDA_ADM_EXAMPLE_TEST_ADM_ENUM_ADM REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM
 
 /*
  * Enumerations for TYPEDEF objects

--- a/test/data/gen_ch/example_test.h
+++ b/test/data/gen_ch/example_test.h
@@ -24,17 +24,17 @@ extern "C" {
  * Defines for the ADM itself
  */
 /// Text name of the organization
-#define REFDA_ADM_EXAMPLE_TEST_ADM_ORG_NAME "example"
+#define REFDA_ADM_EXAMPLE_TEST_ORG_NAME "example"
 /// Enumeration of the organization
-#define REFDA_ADM_EXAMPLE_TEST_ADM_ORG_ENUM 65535
+#define REFDA_ADM_EXAMPLE_TEST_ORG_ENUM 65535
 /// Text name of the model
-#define REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_NAME "test"
+#define REFDA_ADM_EXAMPLE_TEST_MODEL_NAME "test"
 /// Enumeration of the model
-#define REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM 9999
+#define REFDA_ADM_EXAMPLE_TEST_MODEL_ENUM 9999
 /// Revision date for the model
-#define REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_REVISION "2024-11-21"
-/// @deprecated use REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM directly
-#define REFDA_ADM_EXAMPLE_TEST_ADM_ENUM_ADM REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM
+#define REFDA_ADM_EXAMPLE_TEST_MODEL_REVISION "2024-11-21"
+/// @deprecated use REFDA_ADM_EXAMPLE_TEST_MODEL_ENUM directly
+#define REFDA_ADM_EXAMPLE_TEST_ENUM_ADM REFDA_ADM_EXAMPLE_TEST_MODEL_ENUM
 
 /*
  * Enumerations for TYPEDEF objects

--- a/test/data/gen_ch/example_test.h
+++ b/test/data/gen_ch/example_test.h
@@ -20,8 +20,19 @@
 extern "C" {
 #endif
 
-/// Enumeration of the ADM itself
-#define REFDA_ADM_EXAMPLE_TEST_ENUM_ADM 9999
+/*
+ * Defines for the ADM itself
+ */
+/// Text name of the organization
+#define REFDA_ADM_EXAMPLE_TEST_ADM_ORG_NAME "example"
+/// Enumeration of the organization
+#define REFDA_ADM_EXAMPLE_TEST_ADM_ORG_ENUM 65535
+/// Text name of the model
+#define REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_NAME "test"
+/// Enumeration of the model
+#define REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM 9999
+/// Revision date for the model
+#define REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_REVISION "2024-11-21"
 
 /*
  * Enumerations for TYPEDEF objects

--- a/test/data/scrape_ch_same/example_test.c
+++ b/test/data/scrape_ch_same/example_test.c
@@ -330,9 +330,9 @@ int refda_adm_example_test_init(refda_agent_t *agent)
 
     cace_amm_obj_ns_t *adm = cace_amm_obj_store_add_ns(
         &(agent->objs),
-        cace_amm_idseg_ref_withenum(REFDA_ADM_EXAMPLE_TEST_ADM_ORG_NAME, REFDA_ADM_EXAMPLE_TEST_ADM_ORG_ENUM),
-        cace_amm_idseg_ref_withenum(REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_NAME, REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM),
-        REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_REVISION
+        cace_amm_idseg_ref_withenum(REFDA_ADM_EXAMPLE_TEST_ORG_NAME, REFDA_ADM_EXAMPLE_TEST_ORG_ENUM),
+        cace_amm_idseg_ref_withenum(REFDA_ADM_EXAMPLE_TEST_MODEL_NAME, REFDA_ADM_EXAMPLE_TEST_MODEL_ENUM),
+        REFDA_ADM_EXAMPLE_TEST_MODEL_REVISION
     );
     if (adm)
     {

--- a/test/data/scrape_ch_same/example_test.c
+++ b/test/data/scrape_ch_same/example_test.c
@@ -329,8 +329,11 @@ int refda_adm_example_test_init(refda_agent_t *agent)
     /*   STOP CUSTOM PRE-INIT HERE  */
 
     cace_amm_obj_ns_t *adm = cace_amm_obj_store_add_ns(
-        &(agent->objs), cace_amm_idseg_ref_withenum("example", 65535),
-        cace_amm_idseg_ref_withenum("test", REFDA_ADM_EXAMPLE_TEST_ENUM_ADM), "2024-11-21");
+        &(agent->objs),
+        cace_amm_idseg_ref_withenum(REFDA_ADM_EXAMPLE_TEST_ADM_ORG_NAME, REFDA_ADM_EXAMPLE_TEST_ADM_ORG_ENUM),
+        cace_amm_idseg_ref_withenum(REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_NAME, REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM),
+        REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_REVISION
+    );
     if (adm)
     {
         cace_amm_obj_desc_t *obj;

--- a/test/data/scrape_ch_same/example_test.h
+++ b/test/data/scrape_ch_same/example_test.h
@@ -27,17 +27,17 @@ extern "C" {
  * Defines for the ADM itself
  */
 /// Text name of the organization
-#define REFDA_ADM_EXAMPLE_TEST_ADM_ORG_NAME "example"
+#define REFDA_ADM_EXAMPLE_TEST_ORG_NAME "example"
 /// Enumeration of the organization
-#define REFDA_ADM_EXAMPLE_TEST_ADM_ORG_ENUM 65535
+#define REFDA_ADM_EXAMPLE_TEST_ORG_ENUM 65535
 /// Text name of the model
-#define REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_NAME "test"
+#define REFDA_ADM_EXAMPLE_TEST_MODEL_NAME "test"
 /// Enumeration of the model
-#define REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM 9999
+#define REFDA_ADM_EXAMPLE_TEST_MODEL_ENUM 9999
 /// Revision date for the model
-#define REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_REVISION "2024-11-21"
-/// @deprecated use REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM directly
-#define REFDA_ADM_EXAMPLE_TEST_ADM_ENUM_ADM REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM
+#define REFDA_ADM_EXAMPLE_TEST_MODEL_REVISION "2024-11-21"
+/// @deprecated use REFDA_ADM_EXAMPLE_TEST_MODEL_ENUM directly
+#define REFDA_ADM_EXAMPLE_TEST_ENUM_ADM REFDA_ADM_EXAMPLE_TEST_MODEL_ENUM
 
 /*
  * Enumerations for TYPEDEF objects

--- a/test/data/scrape_ch_same/example_test.h
+++ b/test/data/scrape_ch_same/example_test.h
@@ -23,8 +23,19 @@
 extern "C" {
 #endif
 
-/// Enumeration of the ADM itself
-#define REFDA_ADM_EXAMPLE_TEST_ENUM_ADM 9999
+/*
+ * Defines for the ADM itself
+ */
+/// Text name of the organization
+#define REFDA_ADM_EXAMPLE_TEST_ADM_ORG_NAME "example"
+/// Enumeration of the organization
+#define REFDA_ADM_EXAMPLE_TEST_ADM_ORG_ENUM 65535
+/// Text name of the model
+#define REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_NAME "test"
+/// Enumeration of the model
+#define REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM 9999
+/// Revision date for the model
+#define REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_REVISION "2024-11-21"
 
 /*
  * Enumerations for TYPEDEF objects

--- a/test/data/scrape_ch_same/example_test.h
+++ b/test/data/scrape_ch_same/example_test.h
@@ -36,6 +36,8 @@ extern "C" {
 #define REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM 9999
 /// Revision date for the model
 #define REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_REVISION "2024-11-21"
+/// @deprecated use REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM directly
+#define REFDA_ADM_EXAMPLE_TEST_ADM_ENUM_ADM REFDA_ADM_EXAMPLE_TEST_ADM_MODEL_ENUM
 
 /*
  * Enumerations for TYPEDEF objects


### PR DESCRIPTION
CAMP generates both a header (.h) file and .c file with org name, org ID, module name, revision date hardcoded in. We want to define org name, org ID, module name, revision date within the .h file instead of .c.

EXAMPLE: in `&(agent->objs), cace_amm_idseg_ref_withenum("org-name", 5678)` we see the org name and org ID which would be useful as constants in the .h file

My goal is to figure out which CAMP files specify what is in the generated .c and .h files, then define constants in whatever CAMP file(s) that generates the .h file, potentially moving code from the CAMP file(s) that generates the .c file 

My steps were as follows:
1. Define the constants in the header template file (`src/camp/generators/agent.h.jinja`) to create the macros for org name, ID, etc.
2. Inspect/update the Python generator logic to ensure the Python scripts `create_impl_h.py` and `create_impl_c.py` are extracting the values from the input and passing them into the Jinja context (NOTE: I took a look at those files and I believe that is the case, so no updates were made)
3. Refactor the source template by going to agent.c.jinja and replacing the hard-coded strings in functions like `cace_amm_idseg_ref_withenum` with the macros I just created

Remaining steps:
1. Test the changes using pytest run existing tests (NOTE: I tried this and some tests are failing due to my changes)
2. Run CAMP on a sample YANG file and manually check the output to make sure the generated .h and .c files contain the new #define constants
3. Run the formatting script